### PR TITLE
Fix test_readyapi_cli to check both stdout and stderr for error message

### DIFF
--- a/tests/test_readyapi_cli.py
+++ b/tests/test_readyapi_cli.py
@@ -22,7 +22,7 @@ def test_readyapi_cli():
         encoding="utf-8",
     )
     assert result.returncode == 1, result.stdout
-    assert "Path does not exist non_existent_file.py" in result.stdout
+    assert "Path does not exist non_existent_file.py" in (result.stdout + result.stderr)
 
 
 def test_readyapi_cli_not_installed():


### PR DESCRIPTION
Updated test to assert error message presence in both stdout and stderr, ensuring robust test behavior regardless of output stream used by the CLI.